### PR TITLE
Fix auto_shape_type property to raise ValueError for non-autoshapes

### DIFF
--- a/src/pptx/shapes/autoshape.py
+++ b/src/pptx/shapes/autoshape.py
@@ -275,7 +275,7 @@ class Shape(BaseShape):
         Like `MSO_SHAPE.ROUNDED_RECTANGLE`. Raises |ValueError| if this shape is not an auto shape.
         """
         if not self._sp.is_autoshape:
-            return None
+            raise ValueError("shape is not an auto shape")
         return self._sp.prst
 
     @lazyproperty


### PR DESCRIPTION
## Summary
- Fix `auto_shape_type` property to raise `ValueError` when called on non-autoshape shapes
- Aligns behavior with documented API and fixes failing test case

## Test plan
- [x] Existing test `tests/shapes/test_autoshape.py::DescribeShape::but_it_raises_when_auto_shape_type_called_on_non_autoshape` now passes
- [x] All other autoshape tests continue to pass
- [x] Full test suite runs with only 1 pre-existing unrelated failure

🤖 Generated with [Claude Code](https://claude.ai/code)