### PR TITLE
FEP-015: Picture.to_dict() & Image.to_dict() - Picture-Specific Introspection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Systematic addition of introspection capabilities (`to_dict()` methods) across a
 | 012 | Slide | ✅ | Slide properties, shapes/placeholders collections, relationships |
 | 013 | Presentation | ✅ | Top-level presentation introspection, core properties, collections |
 | 014 | PlaceholderFormat | ✅ | Placeholder details (idx, type), enhanced BaseShape integration |
+| 015 | Picture & Image | ✅ | Complete picture/image introspection with crop, mask, and media details |
 
 **Test Architecture:** Refactored from 1,952-line monolith to modular structure (84% size reduction).
 
@@ -117,7 +118,6 @@ class IntrospectionMixin:
 
 ### High Priority
 - **FEP-008:** AutoShape introspection (adjustments, text frames)
-- **FEP-015:** Picture & Media introspection
 
 ### Medium Priority  
 - **FEP-016:** Table introspection
@@ -129,7 +129,7 @@ class IntrospectionMixin:
 ### Low Priority
 - **FEP-021:** Interactive Manipulation Hints
 
-**Progress:** 13/20 FEPs completed (65.0%)
+**Progress:** 14/20 FEPs completed (70.0%)
 
 ## FEP Development Workflow
 

--- a/tests/introspection/test_image_introspection.py
+++ b/tests/introspection/test_image_introspection.py
@@ -1,0 +1,183 @@
+# tests/introspection/test_image_introspection.py
+
+"""
+Unit tests for Image.to_dict() introspection functionality (FEP-015).
+
+Tests the introspection capabilities of Image objects, verifying
+that image properties, metadata, and content information are properly
+serialized in the to_dict() output.
+"""
+
+import unittest
+
+from .mock_helpers import MockImage, assert_basic_to_dict_structure
+
+
+class TestImageIntrospection(unittest.TestCase):
+    """Test Image.to_dict() implementation for comprehensive image introspection."""
+
+    def setUp(self):
+        """Set up test fixtures for Image introspection tests."""
+        self.mock_image = MockImage()
+
+    def test_image_to_dict_basic_structure(self):
+        """Test that Image.to_dict() returns expected basic structure."""
+        result = self.mock_image.to_dict()
+
+        assert_basic_to_dict_structure(self, result, "MockImage")
+        self.assertIn("relationships", result)
+
+    def test_image_identity_section(self):
+        """Test Image._to_dict_identity() includes proper identification."""
+        result = self.mock_image.to_dict()
+        identity = result["_identity"]
+
+        self.assertEqual(identity["class_name"], "MockImage")
+        self.assertIn("description", identity)
+        self.assertIn("test.png", identity["description"])
+        self.assertEqual(identity["filename"], "test.png")
+
+    def test_image_identity_section_without_filename(self):
+        """Test Image._to_dict_identity() for streamed image without filename."""
+        streamed_image = MockImage(filename=None)
+        result = streamed_image.to_dict()
+        identity = result["_identity"]
+
+        self.assertIn("streamed image", identity["description"])
+        self.assertNotIn("filename", identity)
+
+    def test_image_properties_section(self):
+        """Test Image._to_dict_properties() includes all image properties."""
+        result = self.mock_image.to_dict()
+        props = result["properties"]
+
+        # Check basic properties
+        self.assertEqual(props["content_type"], "image/png")
+        self.assertEqual(props["extension"], "png")
+        self.assertEqual(props["sha1_hash"], "abcd1234567890abcd1234567890abcd12345678")
+
+        # Check dimensions
+        self.assertIn("dimensions_px", props)
+        self.assertEqual(props["dimensions_px"]["width"], 800)
+        self.assertEqual(props["dimensions_px"]["height"], 600)
+
+        # Check DPI
+        self.assertIn("dpi", props)
+        self.assertEqual(props["dpi"]["horizontal"], 72)
+        self.assertEqual(props["dpi"]["vertical"], 72)
+
+        # Check blob size
+        self.assertIn("blob_size_bytes", props)
+        self.assertIsInstance(props["blob_size_bytes"], int)
+        self.assertGreater(props["blob_size_bytes"], 0)
+
+    def test_image_relationships_section(self):
+        """Test Image._to_dict_relationships() returns empty dict."""
+        result = self.mock_image.to_dict()
+        relationships = result["relationships"]
+
+        # Image objects don't have relationships
+        self.assertEqual(relationships, {})
+
+    def test_image_llm_context_section(self):
+        """Test Image._to_dict_llm_context() provides helpful descriptions."""
+        result = self.mock_image.to_dict()
+        llm_context = result["_llm_context"]
+
+        self.assertIn("description", llm_context)
+        self.assertIn("summary", llm_context)
+        self.assertIn("common_operations", llm_context)
+
+        # Check description content
+        description = llm_context["description"]
+        self.assertIn("PNG image", description)
+        self.assertIn("800x600 pixels", description)
+        self.assertIn("72x72 DPI", description)
+        self.assertIn("'test.png'", description)
+
+        # Check summary
+        summary = llm_context["summary"]
+        self.assertIn("PNG image", summary)
+        self.assertIn("800x600px", summary)
+
+        # Check operations
+        operations = llm_context["common_operations"]
+        self.assertIsInstance(operations, list)
+        self.assertTrue(len(operations) > 0)
+        self.assertTrue(any("blob" in op for op in operations))
+        self.assertTrue(any("dimensions" in op for op in operations))
+
+    def test_image_different_formats(self):
+        """Test Image introspection for different image formats."""
+        jpg_image = MockImage(filename="photo.jpg", content_type="image/jpeg", ext="jpg")
+        result = jpg_image.to_dict()
+
+        props = result["properties"]
+        self.assertEqual(props["content_type"], "image/jpeg")
+        self.assertEqual(props["extension"], "jpg")
+
+        llm_context = result["_llm_context"]
+        self.assertIn("JPG image", llm_context["description"])
+
+    def test_image_custom_dimensions_and_dpi(self):
+        """Test Image introspection with custom dimensions and DPI."""
+        custom_image = MockImage(
+            filename="large.png",
+            size=(1920, 1080),
+            dpi=(300, 300),
+            blob_size=2000000
+        )
+        result = custom_image.to_dict()
+
+        props = result["properties"]
+        self.assertEqual(props["dimensions_px"]["width"], 1920)
+        self.assertEqual(props["dimensions_px"]["height"], 1080)
+        self.assertEqual(props["dpi"]["horizontal"], 300)
+        self.assertEqual(props["dpi"]["vertical"], 300)
+
+        llm_context = result["_llm_context"]
+        self.assertIn("1920x1080 pixels", llm_context["description"])
+        self.assertIn("300x300 DPI", llm_context["description"])
+
+    def test_image_max_depth_parameter(self):
+        """Test Image introspection respects max_depth parameter."""
+        # Image is a leaf object, so max_depth shouldn't affect its properties
+        result_depth_1 = self.mock_image.to_dict(max_depth=1)
+        result_depth_3 = self.mock_image.to_dict(max_depth=3)
+
+        # Properties should be the same since Image doesn't have nested objects
+        self.assertEqual(result_depth_1["properties"], result_depth_3["properties"])
+
+    def test_image_include_private_parameter(self):
+        """Test Image introspection with include_private parameter."""
+        result_no_private = self.mock_image.to_dict(include_private=False)
+        result_with_private = self.mock_image.to_dict(include_private=True)
+
+        # Image mock doesn't expose private attributes by default
+        # but both should have the same structure
+        self.assertEqual(
+            result_no_private["properties"].keys(),
+            result_with_private["properties"].keys()
+        )
+
+    def test_image_format_for_llm_parameter(self):
+        """Test Image introspection with format_for_llm parameter."""
+        result_no_llm = self.mock_image.to_dict(format_for_llm=False)
+        result_with_llm = self.mock_image.to_dict(format_for_llm=True)
+
+        # Without LLM formatting, should not have _llm_context
+        self.assertNotIn("_llm_context", result_no_llm)
+        self.assertIn("_llm_context", result_with_llm)
+
+    def test_image_include_relationships_parameter(self):
+        """Test Image introspection with include_relationships parameter."""
+        result_no_rels = self.mock_image.to_dict(include_relationships=False)
+        result_with_rels = self.mock_image.to_dict(include_relationships=True)
+
+        # Without relationships, should not have relationships section
+        self.assertNotIn("relationships", result_no_rels)
+        self.assertIn("relationships", result_with_rels)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/introspection/test_picture_introspection.py
+++ b/tests/introspection/test_picture_introspection.py
@@ -1,0 +1,259 @@
+# tests/introspection/test_picture_introspection.py
+
+"""
+Unit tests for Picture.to_dict() introspection functionality (FEP-015).
+
+Tests the introspection capabilities of Picture objects, verifying
+that picture properties, image details, crop settings, and line formatting
+are properly serialized in the to_dict() output.
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from .mock_helpers import MockImage, MockPicture, assert_basic_to_dict_structure
+
+
+class TestPictureIntrospection(unittest.TestCase):
+    """Test Picture.to_dict() implementation for comprehensive picture introspection."""
+
+    def setUp(self):
+        """Set up test fixtures for Picture introspection tests."""
+        self.mock_picture = MockPicture()
+
+    def test_picture_to_dict_basic_structure(self):
+        """Test that Picture.to_dict() returns expected basic structure."""
+        result = self.mock_picture.to_dict()
+
+        assert_basic_to_dict_structure(self, result, "MockPicture")
+        self.assertIn("relationships", result)
+
+    def test_picture_identity_section(self):
+        """Test Picture._to_dict_identity() includes proper identification."""
+        result = self.mock_picture.to_dict()
+        identity = result["_identity"]
+
+        self.assertEqual(identity["class_name"], "Picture")
+        self.assertEqual(identity["shape_id"], 1)
+        self.assertEqual(identity["name"], "Picture 1")
+        self.assertIn("description", identity)
+        self.assertIn("test.png", identity["description"])
+
+    def test_picture_identity_section_without_image(self):
+        """Test Picture._to_dict_identity() for picture without embedded image."""
+        picture_no_image = MockPicture(image=None)
+        picture_no_image._image = None  # Simulate no image
+        result = picture_no_image.to_dict()
+        identity = result["_identity"]
+
+        self.assertIn("no embedded image", identity["description"])
+
+    def test_picture_properties_section(self):
+        """Test Picture._to_dict_properties() includes all picture properties."""
+        result = self.mock_picture.to_dict()
+        props = result["properties"]
+
+        # Check crop properties
+        self.assertEqual(props["crop_left"], 0.0)
+        self.assertEqual(props["crop_top"], 0.0)
+        self.assertEqual(props["crop_right"], 0.0)
+        self.assertEqual(props["crop_bottom"], 0.0)
+
+        # Check image details
+        self.assertIn("image_details", props)
+        image_details = props["image_details"]
+        self.assertEqual(image_details["_object_type"], "MockImage")
+
+        # Check auto shape mask type
+        self.assertIn("auto_shape_mask_type", props)
+
+        # Check line properties
+        self.assertIn("line", props)
+        line_props = props["line"]
+        self.assertEqual(line_props["_object_type"], "MockLineFormat")
+
+    def test_picture_properties_with_cropping(self):
+        """Test Picture._to_dict_properties() with cropping values."""
+        cropped_picture = MockPicture(
+            crop_left=0.1,
+            crop_top=0.05,
+            crop_right=0.15,
+            crop_bottom=0.2
+        )
+        result = cropped_picture.to_dict()
+        props = result["properties"]
+
+        self.assertEqual(props["crop_left"], 0.1)
+        self.assertEqual(props["crop_top"], 0.05)
+        self.assertEqual(props["crop_right"], 0.15)
+        self.assertEqual(props["crop_bottom"], 0.2)
+
+    def test_picture_properties_with_auto_shape_mask(self):
+        """Test Picture._to_dict_properties() with auto shape masking."""
+        # Mock an auto shape type enum
+        mock_oval = Mock()
+        mock_oval.name = "OVAL"
+        mock_oval.value = 9
+
+        masked_picture = MockPicture(auto_shape_type=mock_oval)
+        result = masked_picture.to_dict()
+        props = result["properties"]
+
+        # The auto_shape_mask_type should be formatted properly
+        self.assertIn("auto_shape_mask_type", props)
+
+    def test_picture_properties_max_depth_limitation(self):
+        """Test Picture._to_dict_properties() respects max_depth for nested objects."""
+        result_depth_1 = self.mock_picture.to_dict(max_depth=1)
+        result_depth_3 = self.mock_picture.to_dict(max_depth=3)
+
+        props_depth_1 = result_depth_1["properties"]
+        props_depth_3 = result_depth_3["properties"]
+
+        # At depth 1, line should be truncated (since it uses max_depth-1 = 0)
+        # MockLineFormat inherits from IntrospectionMixin so at depth 0 it returns _truncated
+        if "_depth_exceeded" in props_depth_1["line"]:
+            self.assertEqual(props_depth_1["line"]["_depth_exceeded"], True)
+        elif "_truncated" in props_depth_1["line"]:
+            self.assertIn("_truncated", props_depth_1["line"])
+        else:
+            # Should have one of these truncation indicators
+            self.fail(f"Expected depth limitation in line object: {props_depth_1['line']}")
+
+        # At depth 3, line should be fully expanded
+        self.assertIn("properties", props_depth_3["line"])
+
+    def test_picture_relationships_section(self):
+        """Test Picture._to_dict_relationships() includes image part."""
+        result = self.mock_picture.to_dict()
+        relationships = result["relationships"]
+
+        self.assertIn("image_part", relationships)
+        self.assertEqual(relationships["image_part"], "Mock image part reference")
+
+    def test_picture_llm_context_section(self):
+        """Test Picture._to_dict_llm_context() provides helpful descriptions."""
+        result = self.mock_picture.to_dict()
+        llm_context = result["_llm_context"]
+
+        self.assertIn("description", llm_context)
+        self.assertIn("summary", llm_context)
+        self.assertIn("common_operations", llm_context)
+
+        # Check description content
+        description = llm_context["description"]
+        self.assertIn("PICTURE shape", description)
+        self.assertIn("'Picture 1'", description)
+        self.assertIn("(ID: 1)", description)
+        self.assertIn("test.png", description)
+
+        # Check operations
+        operations = llm_context["common_operations"]
+        self.assertIsInstance(operations, list)
+        self.assertTrue(len(operations) > 0)
+        self.assertTrue(any("crop" in op for op in operations))
+        self.assertTrue(any("image source" in op for op in operations))
+        self.assertTrue(any("mask shape" in op for op in operations))
+
+    def test_picture_llm_context_with_cropping(self):
+        """Test Picture._to_dict_llm_context() describes cropping."""
+        cropped_picture = MockPicture(
+            crop_left=0.1,
+            crop_bottom=0.2
+        )
+        result = cropped_picture.to_dict()
+        llm_context = result["_llm_context"]
+        description = llm_context["description"]
+
+        self.assertIn("Cropped", description)
+        self.assertIn("10.0% from left", description)
+        self.assertIn("20.0% from bottom", description)
+
+    def test_picture_llm_context_with_masking(self):
+        """Test Picture._to_dict_llm_context() describes shape masking."""
+        # Mock an auto shape type enum
+        mock_oval = Mock()
+        mock_oval.name = "OVAL"
+
+        masked_picture = MockPicture(auto_shape_type=mock_oval)
+        result = masked_picture.to_dict()
+        llm_context = result["_llm_context"]
+        description = llm_context["description"]
+
+        self.assertIn("Masked as OVAL", description)
+
+    def test_picture_llm_context_without_image(self):
+        """Test Picture._to_dict_llm_context() handles missing image gracefully."""
+        picture_no_image = MockPicture(image=None)
+        picture_no_image._image = None  # Simulate no image
+        result = picture_no_image.to_dict()
+        llm_context = result["_llm_context"]
+        description = llm_context["description"]
+
+        self.assertIn("no embedded image", description)
+
+    def test_picture_max_depth_parameter(self):
+        """Test Picture introspection respects max_depth parameter."""
+        result_depth_0 = self.mock_picture.to_dict(max_depth=0)
+        result_depth_2 = self.mock_picture.to_dict(max_depth=2)
+
+        # At depth 0, the entire object should be truncated
+        self.assertIn("_truncated", result_depth_0)
+        self.assertNotIn("properties", result_depth_0)
+
+        # At depth 2, nested objects should be expanded
+        props_depth_2 = result_depth_2["properties"]
+        self.assertIn("properties", props_depth_2["line"])
+
+    def test_picture_include_relationships_parameter(self):
+        """Test Picture introspection with include_relationships parameter."""
+        result_no_rels = self.mock_picture.to_dict(include_relationships=False)
+        result_with_rels = self.mock_picture.to_dict(include_relationships=True)
+
+        # Without relationships, should not have relationships section
+        self.assertNotIn("relationships", result_no_rels)
+        self.assertIn("relationships", result_with_rels)
+
+    def test_picture_format_for_llm_parameter(self):
+        """Test Picture introspection with format_for_llm parameter."""
+        result_no_llm = self.mock_picture.to_dict(format_for_llm=False)
+        result_with_llm = self.mock_picture.to_dict(format_for_llm=True)
+
+        # Without LLM formatting, should not have _llm_context
+        self.assertNotIn("_llm_context", result_no_llm)
+        self.assertIn("_llm_context", result_with_llm)
+
+    def test_picture_different_image_types(self):
+        """Test Picture introspection with different image types."""
+        jpg_image = MockImage(filename="photo.jpg", ext="jpg")
+        jpg_picture = MockPicture(image=jpg_image, name="JPEG Picture")
+
+        result = jpg_picture.to_dict()
+        identity = result["_identity"]
+
+        self.assertIn("photo.jpg", identity["description"])
+        self.assertEqual(identity["name"], "JPEG Picture")
+
+    def test_picture_streamed_image(self):
+        """Test Picture introspection with streamed image (no filename)."""
+        streamed_image = MockImage(filename=None, ext="png")
+        streamed_picture = MockPicture(image=streamed_image)
+
+        result = streamed_picture.to_dict()
+        identity = result["_identity"]
+
+        self.assertIn("streamed png image", identity["description"])
+
+    def test_picture_error_handling_for_image_access(self):
+        """Test Picture introspection handles image access errors gracefully."""
+        # This test would be more relevant with real Picture objects
+        # where image access can fail, but we can still test the structure
+        result = self.mock_picture.to_dict()
+
+        # Should not raise exceptions and should have proper structure
+        self.assertIn("image_details", result["properties"])
+        self.assertIn("_object_type", result["properties"]["image_details"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implement comprehensive introspection capabilities for **Picture** and **Image** objects in python-pptx, enabling complete transparency of picture shape properties, image metadata, cropping settings, and masking configurations.

This addresses [FEP-015: Picture.to_dict() - Picture-Specific Introspection #35](https://github.com/oneryalcin/python-pptx/issues/35).

## Key Features Implemented

### 🖼️ **Image Class Introspection** (`src/pptx/parts/image.py`)
- **Identity**: Filename, extension, description of image data
- **Properties**: Content type, dimensions, DPI, SHA1 hash, blob size  
- **Relationships**: Empty (Image is leaf object)
- **LLM Context**: Rich descriptions with file size, dimensions, format details

### 🎨 **Picture Shape Introspection** (`src/pptx/shapes/picture.py`)
- **_BasePicture**: Crop properties introspection (all 4 crop edges)
- **Picture**: Complete picture shape introspection
  - Image details (recursive introspection via Image.to_dict())
  - Auto-shape masking details (oval, rectangle, etc.)
  - Line formatting integration (leverages FEP-006)
  - Enhanced LLM descriptions with cropping and masking context

## Example Output Structure

```json
{
  "_object_type": "Picture",
  "_identity": {
    "class_name": "Picture", 
    "shape_id": 2,
    "name": "Picture 1",
    "description": "Picture shape displaying: my_image.png"
  },
  "properties": {
    "crop_left": 0.1, "crop_top": 0.05, "crop_right": 0.15, "crop_bottom": 0.2,
    "image_details": {
      "_object_type": "Image",
      "properties": {
        "content_type": "image/png",
        "dimensions_px": {"width": 800, "height": 600},
        "dpi": {"horizontal": 72, "vertical": 72},
        "blob_size_bytes": 123456
      }
    },
    "auto_shape_mask_type": {"name": "OVAL", "value": 9},
    "line": { "_object_type": "LineFormat", "properties": {...} }
  },
  "_llm_context": {
    "description": "A PICTURE shape named 'Picture 1' (ID: 2) displaying: my_image.png. Masked as OVAL. Cropped 10.0% from left, 5.0% from top, 15.0% from right, 20.0% from bottom.",
    "summary": "Picture: my_image.png",
    "common_operations": [...]
  }
}
```

## Test Plan

### For Reviewers
```bash
# Activate environment
source venv/bin/activate

# Run new unit tests (30 tests)
python -m pytest tests/introspection/test_image_introspection.py tests/introspection/test_picture_introspection.py -v

# Run comprehensive live test validation
python live_test_picture_introspection.py

# Verify no regressions in existing introspection
python -m pytest tests/introspection/ -v

# Verify overall test suite health
python -m pytest tests/ -k "not test_text" --tb=short
```

### Expected Results
- **30/30 unit tests** should pass (Image: 12, Picture: 18)
- **6/6 live integration tests** should pass
- **All existing introspection tests** should continue passing
- **Zero regressions** in overall test suite

## Advanced Implementation Details

### 🔧 **Technical Features**
- **Robust Error Handling**: Safe property access for image details with graceful fallbacks
- **Recursive Image Introspection**: Full `Image.to_dict()` integration within Picture objects  
- **Shape Masking Support**: Complete `auto_shape_type` introspection for masked pictures
- **Crop Detection**: Intelligent cropping description in LLM context
- **Depth Management**: Proper `max_depth` handling for nested objects

### 🧪 **Test Infrastructure** 
- **Mock Classes**: `MockImage` and `MockPicture` with complete introspection capabilities
- **Unit Tests**: Comprehensive mock-based testing covering all scenarios
- **Live Tests**: Real PowerPoint object validation with actual image files
- **Edge Cases**: No image, streamed images, cropping, masking, parameter validation

### 🔗 **FEP Integration**
**Leverages Previous FEPs:**
- FEP-001: Core IntrospectionMixin architecture
- FEP-002: Enum formatting for `auto_shape_type`  
- FEP-006: LineFormat introspection for picture borders

**Benefits for Future FEPs:**
- Picture objects now fully introspectable for slide-level collections
- Image objects provide complete metadata for media introspection

## Validation Results

### 🧪 **Live Test Results**
```
FEP-015 Live Test: Picture.to_dict() Introspection
============================================================
✅ Image introspection test PASSED
✅ Basic Picture introspection test PASSED  
✅ Cropped Picture introspection test PASSED
✅ Masked Picture introspection test PASSED
✅ Picture parameters test PASSED
✅ Error handling test PASSED

🎉 All tests PASSED\! FEP-015 implementation is working correctly.
```

### 📊 **Unit Test Results** 
```
tests/introspection/test_image_introspection.py: 12 PASSED
tests/introspection/test_picture_introspection.py: 18 PASSED
Total: 30/30 tests passing (100% success rate)
```

## Files Modified
- `src/pptx/parts/image.py` - Added Image introspection
- `src/pptx/shapes/picture.py` - Added Picture and _BasePicture introspection  
- `tests/introspection/mock_helpers.py` - Added MockImage and MockPicture classes
- `tests/introspection/test_image_introspection.py` - New Image test suite (12 tests)
- `tests/introspection/test_picture_introspection.py` - New Picture test suite (18 tests)
- `CLAUDE.md` - Updated progress: 14/20 FEPs completed (70.0%)

## Progress Update
- **Completed FEPs**: 14/20 (70.0% of roadmap)
- **Next Priority**: FEP-008 (AutoShape introspection)

---

**Live Test Script**: The `live_test_picture_introspection.py` script demonstrates the complete functionality with real PowerPoint objects and is included for engineer validation.

🤖 Generated with [Claude Code](https://claude.ai/code)